### PR TITLE
find bwa from path

### DIFF
--- a/tests/test_tpp.py
+++ b/tests/test_tpp.py
@@ -17,11 +17,7 @@ import pytpp.__main__
 tppMain = pytpp.__main__.main
 
 def get_bwa():
-    if (os.path.exists("/usr/bin/bwa")):
-        return "/usr/bin/bwa"
-    elif (os.path.exists("/usr/local/bin/bwa")):
-        return "/usr/local/bin/bwa"
-    return ""
+    return shutil.which("bwa") if not None else None
 
 bwa_path = get_bwa()
 


### PR DESCRIPTION
Hello,

this small modification allows `bwa` to be found based on the user PATH.
since python-3.3 `shutil.which()` to provide a cross-platform means of discovering executables.

I had to modify the test suite in order to find bwa, which in our cas is provided by module environment. so in a non canonical location.

regards

Erc